### PR TITLE
Upgrade to minimatch 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": ["karma", "commonjs", "browserify", "test"],
   "dependencies": {
     "browser-builtins": "^3.2.0",
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.3",
     "resolve": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
When installing karma-common, npm gives this warning:

    npm WARN deprecated minimatch@1.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

This commit follows that advice and upgrades the dependency.